### PR TITLE
Added a catch if there are no peers.

### DIFF
--- a/zrx.js
+++ b/zrx.js
@@ -25,7 +25,10 @@ Zrx.prototype.peers = function(name) {
     .link('http://rels.zettajs.io/server', name)
     .catch(Rx.Observable.empty());
 
-  var peer = siren().load(this.root).link('http://rels.zettajs.io/peer', name);
+  var peer = siren()
+    .load(this.root)
+    .link('http://rels.zettajs.io/peer', name)
+    .catch(Rx.Observable.empty());
 
   return new Zrx(server.merge(peer));
 };


### PR DESCRIPTION
Fixes a ZRX issue that stops API consumption when no peers are present in the API.
